### PR TITLE
Tweak definitions order, resolve circular dependency

### DIFF
--- a/src/ringhopper-definitions/json/tag/damage_effect.json
+++ b/src/ringhopper-definitions/json/tag/damage_effect.json
@@ -84,81 +84,6 @@
         "width": 32
     },
     {
-        "name": "DamageEffectDamage",
-        "fields": [
-            {
-                "name": "side effect",
-                "type": "DamageEffectSideEffect"
-            },
-            {
-                "name": "category",
-                "type": "DamageEffectCategory"
-            },
-            {
-                "name": "flags",
-                "type": "DamageEffectDamageFlags"
-            },
-            {
-                "name": "AOE core radius",
-                "type": "float",
-                "unit": "world units"
-            },
-            {
-                "name": "lower bound",
-                "type": "float"
-            },
-            {
-                "name": "upper bound",
-                "type": "float",
-                "bounds": true
-            },
-            {
-                "name": "vehicle passthrough penalty",
-                "type": "float"
-            },
-            {
-                "name": "active camouflage damage",
-                "type": "float"
-            },
-            {
-                "name": "stun",
-                "type": "float",
-                "minimum": 0.0,
-                "maximum": 1.0
-            },
-            {
-                "name": "maximum stun",
-                "type": "float",
-                "minimum": 0.0,
-                "maximum": 1.0
-            },
-            {
-                "name": "stun time",
-                "type": "float",
-                "unit": "seconds"
-            },
-            {
-                "type": "pad",
-                "size": 4
-            },
-            {
-                "name": "instantaneous acceleration",
-                "type": "Vector3D"
-            },
-            {
-                "heading": "Modifiers",
-                "body": "Damage is multiplied by these modifiers based on the material the damage is applied to.",
-                "type": "editor_section"
-            },
-            {
-                "name": "modifiers",
-                "type": "DamageEffectMaterialModifier"
-            }
-        ],
-        "size": 220,
-        "type": "struct"
-    },
-    {
         "name": "DamageEffectMaterialModifier",
         "fields": [
             {
@@ -300,6 +225,81 @@
         ],
         "type": "struct",
         "size": 160
+    },
+    {
+        "name": "DamageEffectDamage",
+        "fields": [
+            {
+                "name": "side effect",
+                "type": "DamageEffectSideEffect"
+            },
+            {
+                "name": "category",
+                "type": "DamageEffectCategory"
+            },
+            {
+                "name": "flags",
+                "type": "DamageEffectDamageFlags"
+            },
+            {
+                "name": "AOE core radius",
+                "type": "float",
+                "unit": "world units"
+            },
+            {
+                "name": "lower bound",
+                "type": "float"
+            },
+            {
+                "name": "upper bound",
+                "type": "float",
+                "bounds": true
+            },
+            {
+                "name": "vehicle passthrough penalty",
+                "type": "float"
+            },
+            {
+                "name": "active camouflage damage",
+                "type": "float"
+            },
+            {
+                "name": "stun",
+                "type": "float",
+                "minimum": 0.0,
+                "maximum": 1.0
+            },
+            {
+                "name": "maximum stun",
+                "type": "float",
+                "minimum": 0.0,
+                "maximum": 1.0
+            },
+            {
+                "name": "stun time",
+                "type": "float",
+                "unit": "seconds"
+            },
+            {
+                "type": "pad",
+                "size": 4
+            },
+            {
+                "name": "instantaneous acceleration",
+                "type": "Vector3D"
+            },
+            {
+                "heading": "Modifiers",
+                "body": "Damage is multiplied by these modifiers based on the material the damage is applied to.",
+                "type": "editor_section"
+            },
+            {
+                "name": "modifiers",
+                "type": "DamageEffectMaterialModifier"
+            }
+        ],
+        "size": 220,
+        "type": "struct"
     },
     {
         "name": "DamageEffectBreakingEffect",

--- a/src/ringhopper-definitions/json/tag/particle.json
+++ b/src/ringhopper-definitions/json/tag/particle.json
@@ -9,15 +9,6 @@
         "type": "enum"
     },
     {
-        "name": "ParticleAnchor",
-        "options": [
-            "with primary",
-            "with screen space",
-            "zsprite"
-        ],
-        "type": "enum"
-    },
-    {
         "name": "ParticleFlags",
         "type": "bitfield",
         "fields": [

--- a/src/ringhopper-definitions/json/tag/shader_effect.json
+++ b/src/ringhopper-definitions/json/tag/shader_effect.json
@@ -42,6 +42,15 @@
         "size": 76
     },
     {
+        "name": "ParticleAnchor",
+        "options": [
+            "with primary",
+            "with screen space",
+            "zsprite"
+        ],
+        "type": "enum"
+    },
+    {
         "name": "ShaderEffectSecondaryMap",
         "fields": [
             {


### PR DESCRIPTION
I resolved a circular dependency issue on the `particles.json` by moving the `ParticleAnchor` enum to `shader_effect.json`, which is the only definition that actually uses it. Also I changed the order on which the `DamageEffectDamage` is defined in the `damage_effect.json` so the generator for the C headers stops complaining.